### PR TITLE
Do not count bots as new users

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -227,7 +227,8 @@ class listener implements EventSubscriberInterface
 			// total new users in the last 24 hours, counts inactive users as well
 			$sql = 'SELECT COUNT(user_id) AS new_users
 					FROM ' . USERS_TABLE . '
-					WHERE user_regdate > ' . $this->interval;
+					WHERE user_regdate > ' . $this->interval . '
+						AND user_type <> ' . USER_IGNORE;
 			$result = $this->db->sql_query($sql);
 			$activity['users'] = $this->db->sql_fetchfield('new_users');
 			$this->db->sql_freeresult($result);


### PR DESCRIPTION
If admin adds a bot in ACP, the ext count it as new registered user. That seems to be misleading as there're no new real users registered actually.